### PR TITLE
Update sushi-config.yaml

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -53,8 +53,8 @@ pages:
    title: FHIR Guidance
   fhirdesignbackground.md:
    title: FHIR Design Background
-  fhirexamples.md:
-    title:  FHIR Examples
+#  fhirexamples.md:
+#    title:  FHIR Examples
   terminology.md:
     title: Terminology        
   externalstandards.md:


### PR DESCRIPTION
Removing FHIR Examples page as the content is all on the FHIR Health Maintenance Page (which is also accessible via the main drop down menu)